### PR TITLE
Fix: only add 5 minutes to YouTube start time when minutes are :25 or…

### DIFF
--- a/src/Domain/Round/IFSCRoundFactory.php
+++ b/src/Domain/Round/IFSCRoundFactory.php
@@ -90,9 +90,13 @@ final readonly class IFSCRoundFactory
             DateTimeInterface::RFC3339,
         );
 
-        return new DateTimeImmutable($schedulesStartTime)
-            ->modify('+5 minutes')
-            ->setTimezone($event->timeZone);
+        $startTime = new DateTimeImmutable($schedulesStartTime);
+
+        if (in_array((int) $startTime->format('i'), [25, 55], strict: true)) {
+            $startTime = $startTime->modify('+5 minutes');
+        }
+
+        return $startTime->setTimezone($event->timeZone);
     }
 
     private function findLiveStream(IFSCEventInfo $event, string $roundName): LiveStream

--- a/tests/unit/Domain/Round/IFSCRoundFactoryTest.php
+++ b/tests/unit/Domain/Round/IFSCRoundFactoryTest.php
@@ -104,6 +104,26 @@ final class IFSCRoundFactoryTest extends TestCase
         $this->assertSame('2024-04-12T19:00:00+08:00', $this->formatDate($round->endTime));
     }
 
+    #[Test] public function youtube_time_without_rounding_is_used_as_is(): void
+    {
+        $roundFactory = $this->roundFactoryReturningLiveStreamWith(
+            scheduledStartTime: '2024-04-12T10:30:00Z',
+            duration: 60,
+        );
+
+        $round = $roundFactory->create(
+            event: $this->createEvent(),
+            roundName: "Men's & Women's Lead Qualification",
+            startTime: $this->createDateTime('2024-04-12 18:30'),
+            endTime: $this->createDateTime('2024-04-12 21:23'),
+            status: IFSCRoundStatus::PROVISIONAL,
+        );
+
+        $this->assertSame(IFSCRoundStatus::CONFIRMED, $round->status);
+        $this->assertSame('2024-04-12T18:30:00+08:00', $this->formatDate($round->startTime));
+        $this->assertSame('2024-04-12T19:30:00+08:00', $this->formatDate($round->endTime));
+    }
+
     private function roundFactoryReturningLiveStreamWith(?string $scheduledStartTime, int $duration): IFSCRoundFactory
     {
         return new IFSCRoundFactory(


### PR DESCRIPTION
… :55

The buildStartTime() method was unconditionally adding 5 minutes to the YouTube scheduled start time, causing round times like 4:30 to become 4:35.

Now it only rounds up when the minute value is :25 or :55, to round to the nearest half-hour or hour respectively. Other times are used as-is.